### PR TITLE
finish activity when onbackpressed bug occurs

### DIFF
--- a/app/src/main/java/awais/instagrabber/activities/MainActivity.java
+++ b/app/src/main/java/awais/instagrabber/activities/MainActivity.java
@@ -215,6 +215,7 @@ public class MainActivity extends BaseLanguageActivity implements FragmentManage
                 super.onBackPressed();
             } catch (Exception e) {
                 Log.e(TAG, "onBackPressed: ", e);
+                finish();
             }
         }
     }


### PR DESCRIPTION
Required so the activity finishes when the bug occurs. Current workaround makes the back button unresponsive